### PR TITLE
MS Fix

### DIFF
--- a/public_html/plugins/activedirectory/index.js
+++ b/public_html/plugins/activedirectory/index.js
@@ -80,19 +80,19 @@ Node.ActiveDirectory.authenticate = async function (username, password)
 /**
  * Checks if a user is a member of a specific group.
  * Recursively checks nested group memberships.
+ * @param {String} username - Username to check for membership (can be UPN, DN, or simple username)
+ * @param {String} groupName - Group name to check for membership (can be CN or DN)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} username - Username to check for membership (can be UPN, DN, or simple username)
- * @param {String} groupName - Group name to check for membership (can be CN or DN)
  * @returns {Promise<Boolean>} True if user is member of the group, false otherwise
  */
-Node.ActiveDirectory.isUserMemberOf = async function (options, username, groupName)
+Node.ActiveDirectory.isUserMemberOf = async function (username, groupName, options)
 {
-  return await this.exec("isUserMemberOf", [options, username, groupName]);
+  return await this.exec("isUserMemberOf", [username, groupName, options]);
 };
 
 
@@ -116,36 +116,36 @@ Node.ActiveDirectory.find = async function (options)
 /**
  * Finds a user by username and retrieves their information.
  * Searches for the user in the Active Directory and returns their attributes.
+ * @param {String} username - Username to search for (can be UPN, DN, or simple username)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} username - Username to search for (can be UPN, DN, or simple username)
  * @returns {Promise<Object>} User object with attributes or null if not found
  */
-Node.ActiveDirectory.findUser = async function (options, username)
+Node.ActiveDirectory.findUser = async function (username, options)
 {
-  return await this.exec("findUser", [options, username]);
+  return await this.exec("findUser", [username, options]);
 };
 
 
 /**
  * Finds a group by name and retrieves its information.
  * Searches for the group in the Active Directory and returns its attributes.
+ * @param {String} groupName - Group name to search for (can be CN or DN)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} groupName - Group name to search for (can be CN or DN)
  * @returns {Promise<Object>} Group object with attributes or null if not found
  */
-Node.ActiveDirectory.findGroup = async function (options, groupName)
+Node.ActiveDirectory.findGroup = async function (groupName, options)
 {
-  return await this.exec("findGroup", [options, groupName]);
+  return await this.exec("findGroup", [groupName, options]);
 };
 
 
@@ -185,89 +185,89 @@ Node.ActiveDirectory.findGroups = async function (options)
 
 /**
  * Checks if a group exists in Active Directory.
+ * @param {String} groupName - Group name to check (can be CN or DN)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} groupName - Group name to check (can be CN or DN)
  * @returns {Promise<Boolean>} True if the group exists, false otherwise
  */
-Node.ActiveDirectory.groupExists = async function (options, groupName)
+Node.ActiveDirectory.groupExists = async function (groupName, options)
 {
-  return await this.exec("groupExists", [options, groupName]);
+  return await this.exec("groupExists", [groupName, options]);
 };
 
 
 /**
  * Checks if a user exists in Active Directory.
+ * @param {String} username - Username to check (can be UPN, DN, or simple username)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} username - Username to check (can be UPN, DN, or simple username)
  * @returns {Promise<Boolean>} True if the user exists, false otherwise
  */
-Node.ActiveDirectory.userExists = async function (options, username)
+Node.ActiveDirectory.userExists = async function (username, options)
 {
-  return await this.exec("userExists", [options, username]);
+  return await this.exec("userExists", [username, options]);
 };
 
 
 /**
  * Gets all groups that a group is a member of (nested group membership).
  * Recursively retrieves parent groups up the hierarchy.
+ * @param {String} groupName - Group name to retrieve membership for (can be CN or DN)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} groupName - Group name to retrieve membership for (can be CN or DN)
  * @returns {Promise<Array<Object>>} Array of parent group objects
  */
-Node.ActiveDirectory.getGroupMembershipForGroup = async function (options, groupName)
+Node.ActiveDirectory.getGroupMembershipForGroup = async function (groupName, options)
 {
-  return await this.exec("getGroupMembershipForGroup", [options, groupName]);
+  return await this.exec("getGroupMembershipForGroup", [groupName, options]);
 };
 
 
 /**
  * Gets all groups that a user belongs to.
  * Recursively retrieves nested group memberships.
+ * @param {String} username - Username to retrieve membership for (can be UPN, DN, or simple username)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} username - Username to retrieve membership for (can be UPN, DN, or simple username)
  * @returns {Promise<Array<Object>>} Array of group objects the user belongs to
  */
-Node.ActiveDirectory.getGroupMembershipForUser = async function (options, username)
+Node.ActiveDirectory.getGroupMembershipForUser = async function (username, options)
 {
-  return await this.exec("getGroupMembershipForUser", [options, username]);
+  return await this.exec("getGroupMembershipForUser", [username, options]);
 };
 
 
 /**
  * Gets all users that belong to a group.
  * Recursively retrieves users from nested groups.
+ * @param {String} groupName - Group name to retrieve members from (can be CN or DN)
  * @param {Object} [options] - Optional LDAP query parameters
  * @param {String} [options.scope] - LDAP search scope (base, one, or sub)
  * @param {String} [options.filter] - Additional LDAP filter to apply
  * @param {Array<String>} [options.attributes] - Specific attributes to return
  * @param {Number} [options.sizeLimit] - Maximum number of entries to return
  * @param {Number} [options.timelimit] - Maximum time in seconds for the search
- * @param {String} groupName - Group name to retrieve members from (can be CN or DN)
  * @returns {Promise<Array<Object>>} Array of user objects that are members of the group
  */
-Node.ActiveDirectory.getUsersForGroup = async function (options, groupName)
+Node.ActiveDirectory.getUsersForGroup = async function (groupName, options)
 {
-  return await this.exec("getUsersForGroup", [options, groupName]);
+  return await this.exec("getUsersForGroup", [groupName, options]);
 };
 
 

--- a/public_html/plugins/activedirectory/ldapclient.js
+++ b/public_html/plugins/activedirectory/ldapclient.js
@@ -472,16 +472,16 @@ LdapClient.prototype.authenticate = async function (username, password)
  * `userPrincipalName` when given a plain username, or `distinguishedName`
  * when given a DN. Returns the user's attributes, picking the default set
  * unless `options.attributes` overrides it.
+ * @param {String} username - User identifier (DN, sAMAccountName, or UPN)
  * @param {Object} [options] - Search options
  * @param {String} [options.scope] - LDAP scope (`base`, `one`, or `sub`)
  * @param {String} [options.filter] - Extra filter AND-combined with the user filter
  * @param {Array<String>} [options.attributes] - Attributes to retrieve
  * @param {Number} [options.sizeLimit] - Maximum entries to return
  * @param {Number} [options.timelimit] - Maximum search time in seconds
- * @param {String} username - User identifier (DN, sAMAccountName, or UPN)
  * @returns {Promise<Object|null>} The user attributes, or null if not found
  */
-LdapClient.prototype.findUser = async function (options, username)
+LdapClient.prototype.findUser = async function (username, options)
 {
   let requested = options?.attributes || DEFAULT_USER_ATTRIBUTES;
   let baseOpts = {
@@ -504,16 +504,16 @@ LdapClient.prototype.findUser = async function (options, username)
  * name, or `distinguishedName` when given a DN. Returns the group's
  * attributes, picking the default set unless `options.attributes`
  * overrides it.
+ * @param {String} groupName - Group identifier (DN or CN)
  * @param {Object} [options] - Search options
  * @param {String} [options.scope] - LDAP scope (`base`, `one`, or `sub`)
  * @param {String} [options.filter] - Extra filter AND-combined with the group filter
  * @param {Array<String>} [options.attributes] - Attributes to retrieve
  * @param {Number} [options.sizeLimit] - Maximum entries to return
  * @param {Number} [options.timelimit] - Maximum search time in seconds
- * @param {String} groupName - Group identifier (DN or CN)
  * @returns {Promise<Object|null>} The group attributes, or null if not found
  */
-LdapClient.prototype.findGroup = async function (options, groupName)
+LdapClient.prototype.findGroup = async function (groupName, options)
 {
   let requested = options?.attributes || DEFAULT_GROUP_ATTRIBUTES;
   let baseOpts = {
@@ -612,13 +612,13 @@ LdapClient.prototype.findGroups = async function (options)
 /**
  * Checks whether the given user exists in the directory. Internally performs
  * a `findUser` and casts the result to a boolean.
- * @param {Object} [options] - Search options (see {@link LdapClient#findUser})
  * @param {String} username - User identifier (DN, sAMAccountName, or UPN)
+ * @param {Object} [options] - Search options (see {@link LdapClient#findUser})
  * @returns {Promise<Boolean>} True if the user exists, false otherwise
  */
-LdapClient.prototype.userExists = async function (options, username)
+LdapClient.prototype.userExists = async function (username, options)
 {
-  let user = await this.findUser(options, username);
+  let user = await this.findUser(username, options);
   return !!user;
 };
 
@@ -626,13 +626,13 @@ LdapClient.prototype.userExists = async function (options, username)
 /**
  * Checks whether the given group exists in the directory. Internally performs
  * a `findGroup` and casts the result to a boolean.
- * @param {Object} [options] - Search options (see {@link LdapClient#findGroup})
  * @param {String} groupName - Group identifier (DN or CN)
+ * @param {Object} [options] - Search options (see {@link LdapClient#findGroup})
  * @returns {Promise<Boolean>} True if the group exists, false otherwise
  */
-LdapClient.prototype.groupExists = async function (options, groupName)
+LdapClient.prototype.groupExists = async function (groupName, options)
 {
-  let group = await this.findGroup(options, groupName);
+  let group = await this.findGroup(groupName, options);
   return !!group;
 };
 
@@ -643,12 +643,12 @@ LdapClient.prototype.groupExists = async function (options, groupName)
  * LDAP_MATCHING_RULE_IN_CHAIN (OID `1.2.840.113556.1.4.1941`) so no
  * client-side recursion is performed. Resolves both identifiers to their DNs
  * first; returns false when either cannot be resolved.
- * @param {Object} [options] - Reserved for future use; currently ignored
  * @param {String} username - User identifier (DN, sAMAccountName, or UPN)
  * @param {String} groupName - Group identifier (DN or CN)
+ * @param {Object} [options] - Reserved for future use; currently ignored
  * @returns {Promise<Boolean>} True if the user belongs to the group (directly or transitively)
  */
-LdapClient.prototype.isUserMemberOf = async function (options, username, groupName)
+LdapClient.prototype.isUserMemberOf = async function (username, groupName, options)
 {
   return await this._withClient(async client => {
     let userDN = await this._resolveDN(client, "user", username);
@@ -672,16 +672,16 @@ LdapClient.prototype.isUserMemberOf = async function (options, username, groupNa
  * Returns every group the user belongs to, recursing through nested
  * memberships. Implemented server-side via LDAP_MATCHING_RULE_IN_CHAIN so the
  * server walks the membership graph and returns the full transitive closure.
+ * @param {String} username - User identifier (DN, sAMAccountName, or UPN)
  * @param {Object} [options] - Search options
  * @param {String} [options.scope] - LDAP scope (`base`, `one`, or `sub`)
  * @param {String} [options.filter] - Extra filter AND-combined with the group filter
  * @param {Array<String>} [options.attributes] - Attributes to retrieve on each group
  * @param {Number} [options.sizeLimit] - Maximum entries to return
  * @param {Number} [options.timelimit] - Maximum search time in seconds
- * @param {String} username - User identifier (DN, sAMAccountName, or UPN)
  * @returns {Promise<Array<Object>>} Groups the user is a (transitive) member of
  */
-LdapClient.prototype.getGroupMembershipForUser = async function (options, username)
+LdapClient.prototype.getGroupMembershipForUser = async function (username, options)
 {
   return await this._withClient(async client => {
     let userDN = await this._resolveDN(client, "user", username);
@@ -706,16 +706,16 @@ LdapClient.prototype.getGroupMembershipForUser = async function (options, userna
  * Returns every parent group the given group belongs to, recursing up the
  * hierarchy. Implemented server-side via LDAP_MATCHING_RULE_IN_CHAIN on the
  * `member` attribute.
+ * @param {String} groupName - Group identifier (DN or CN)
  * @param {Object} [options] - Search options
  * @param {String} [options.scope] - LDAP scope (`base`, `one`, or `sub`)
  * @param {String} [options.filter] - Extra filter AND-combined with the group filter
  * @param {Array<String>} [options.attributes] - Attributes to retrieve on each group
  * @param {Number} [options.sizeLimit] - Maximum entries to return
  * @param {Number} [options.timelimit] - Maximum search time in seconds
- * @param {String} groupName - Group identifier (DN or CN)
  * @returns {Promise<Array<Object>>} Parent groups (transitive closure)
  */
-LdapClient.prototype.getGroupMembershipForGroup = async function (options, groupName)
+LdapClient.prototype.getGroupMembershipForGroup = async function (groupName, options)
 {
   return await this._withClient(async client => {
     let groupDN = await this._resolveDN(client, "group", groupName);
@@ -741,16 +741,16 @@ LdapClient.prototype.getGroupMembershipForGroup = async function (options, group
  * groups. Implemented server-side via LDAP_MATCHING_RULE_IN_CHAIN on the
  * `memberOf` attribute, so the matching is performed by the directory and
  * range retrieval is not needed on the group's `member` attribute.
+ * @param {String} groupName - Group identifier (DN or CN)
  * @param {Object} [options] - Search options
  * @param {String} [options.scope] - LDAP scope (`base`, `one`, or `sub`)
  * @param {String} [options.filter] - Extra filter AND-combined with the user filter
  * @param {Array<String>} [options.attributes] - Attributes to retrieve on each user
  * @param {Number} [options.sizeLimit] - Maximum entries to return
  * @param {Number} [options.timelimit] - Maximum search time in seconds
- * @param {String} groupName - Group identifier (DN or CN)
  * @returns {Promise<Array<Object>>} Users that are members (transitive) of the group
  */
-LdapClient.prototype.getUsersForGroup = async function (options, groupName)
+LdapClient.prototype.getUsersForGroup = async function (groupName, options)
 {
   return await this._withClient(async client => {
     let groupDN = await this._resolveDN(client, "group", groupName);


### PR DESCRIPTION
The legacy activedirectory@0.7.2 lib used `(options, identifier)`, IndeRT user-API reordered to `(identifier, options)` for ergonomics, but the wire payload and the CC receiver kept the legacy order. Since the CC plugin had never been functional (latent `this.config = undefined` bug, present since the plugin was ported years ago), we can safely unify to the user-friendly convention everywhere.

- index.js: 8 static methods + inner exec arrays + JSDoc
- ldapclient.js: 8 prototype signatures + JSDoc (mirror of IndeRT)

Wire payload now identical byte-for-byte between IndeRT and CC after the change (verified with mock dispatch tests on both stacks).