### PR TITLE
MS - Hardening transazione SQL Server e diagnostica versione driver

### DIFF
--- a/public_html/cloudServer.js
+++ b/public_html/cloudServer.js
@@ -562,10 +562,11 @@ class CloudServer
       }
     };
     data.server = server;
+    let dm;
     try {
       let result;
       if (data.dm) {
-        let dm = this.dataModelByName(data.dm);
+        dm = this.dataModelByName(data.dm);
         if (!dm)
           throw new Error(`Datamodel '${data.dm}' not found`);
         //
@@ -600,9 +601,15 @@ class CloudServer
       msg.data.result = result;
     }
     catch (e) {
-      e = e.message || e.toString();
-      this.log("ERROR", `Error executing '${data.cmd}': ${e}`);
-      msg.data.error = e;
+      let stack = e.stack;
+      this.log("ERROR", `Error executing '${data.cmd}': ${stack || e.message || e}`);
+      msg.data.error = e.message || e.toString();
+      //
+      // Forward the connector-side stack and driver version so the runtime can
+      // diagnose a version/install skew that the bare error message would hide
+      msg.data.errorStack = stack;
+      if (dm)
+        msg.data.driverInfo = dm.getDriverInfo();
     }
     //
     server.sendMessage(msg);

--- a/public_html/db/datamodel.js
+++ b/public_html/db/datamodel.js
@@ -150,6 +150,25 @@ class DataModel
 
 
   /**
+   * Returns a human-readable descriptor of the loaded driver module and its
+   * version, reported alongside errors so the runtime can spot a version/install skew.
+   * @returns {String} Driver descriptor, e.g. "mssql@12.2.1"
+   */
+  getDriverInfo()
+  {
+    let version;
+    try {
+      version = require(`${this.moduleName}/package.json`).version;
+    }
+    catch {
+      version = "unknown";
+    }
+    //
+    return `${this.moduleName}@${version}`;
+  }
+
+
+  /**
    * Initializes the database connection pool if not already created.
    * Delegates to driver-specific _initPool implementation.
    */

--- a/public_html/db/sqlserver.js
+++ b/public_html/db/sqlserver.js
@@ -230,8 +230,8 @@ class SQLServer extends DataModel
     let tr = new mssql.Transaction(this.pool);
     await tr.begin();
     //
-    this.onRollback = () => this.parent.log("WARNING", `transaction on ${this.name} aborted unexpectedly`);
-    tr.on("rollback", this.onRollback);
+    tr._onRollback = () => this.parent.log("WARNING", `transaction on ${this.name} aborted unexpectedly`);
+    tr.on("rollback", tr._onRollback);
     //
     return tr;
   }
@@ -256,8 +256,30 @@ class SQLServer extends DataModel
    */
   async _rollbackTransaction(conn)
   {
-    conn.transaction.off("rollback", this.onRollback);
+    let handler = conn.transaction._onRollback;
+    if (handler)
+      conn.transaction.off("rollback", handler);
     await conn.transaction.rollback();
+  }
+
+
+  /**
+   * Appends the tedious transport version to the driver descriptor, so a
+   * mssql/tedious skew (the cause of the rollback-listener error) is visible.
+   * @returns {String} Driver descriptor, e.g. "mssql@12.2.1, tedious@19.2.1"
+   * @override
+   */
+  getDriverInfo()
+  {
+    let info = super.getDriverInfo();
+    try {
+      info += `, tedious@${require("tedious/package.json").version}`;
+    }
+    catch {
+      // tedious version not resolvable
+    }
+    //
+    return info;
   }
 
 


### PR DESCRIPTION
## Contesto
Con un Data Model verso SQL Server, l'apertura transazione (`begin`) poteva fallire con `The listener argument must be of type function. Received undefined`: le letture funzionavano, ogni scrittura (`doc.save()` apre `begin`/`commit`) falliva.

La causa prima è uno skew di versione/install del connettore (`mssql`/`tedious` disallineati rispetto al pin `mssql@12.2.1`): con il pin attuale, `Transaction._abort` è definito nel costruttore e il `begin` è pulito. Questa PR affronta la fragilità reale nel nostro codice e la diagnostica, indipendenti dallo skew.

## Modifiche
- **`db/sqlserver.js`** — l'handler dell'evento `rollback` era su `this.onRollback` (istanza datamodel), condiviso tra transazioni concorrenti: la seconda `_beginTransaction` lo sovrascriveva e `_rollbackTransaction` poteva rimuovere l'handler errato o passare `undefined` a `.off()`. Ora vive su `tr._onRollback` e la `.off()` è guardata.
- **`cloudServer.js`** — il ramo error inoltrava al runtime solo la stringa del messaggio, perdendo lo stack lato connettore. Ora propaga `errorStack` e `driverInfo`.
- **`db/datamodel.js` + `db/sqlserver.js`** — `getDriverInfo()`: descrittore del driver con le versioni effettive (base `mssql@x.y.z`, override SQL Server con `tedious@..`), così il prossimo report identifica lo skew.

## Repo correlato
Lato runtime: PR su `progamma/IndeRT` (#14437) — stesso hardening sul mirror e `handleCloudConnectorMsg` che fa emergere stack + descrittore driver.

## Test
- [ ] Connettore aggiornato (`node_modules` pulito) → `doc.save()` su SQL Server apre `begin`, INSERT committata
- [ ] Transazioni concorrenti sullo stesso datamodel → nessun `off(undefined)`
- [ ] `begin` fallito → errore al runtime con stack + versione driver
- [ ] Regressione: letture continuano a funzionare