### PR TITLE
MS - Align fs/ and db/ driver mirrors with IndeRT

### DIFF
--- a/public_html/db/mysql.js
+++ b/public_html/db/mysql.js
@@ -77,7 +77,20 @@ class MySQL extends DataModel
    */
   async _closeConnection(conn)
   {
-    conn.release();
+    try {
+      conn.release();
+    }
+    catch {
+      // Ensure the connection is destroyed if release fails
+      // This removes corrupted connections from the pool
+      try {
+        conn.destroy();
+      }
+      catch {
+        // Ignore destroy errors - connection is already broken
+      }
+      // Don't re-throw - we've handled the error by destroying the connection
+    }
   }
 
 

--- a/public_html/db/oracle.js
+++ b/public_html/db/oracle.js
@@ -67,6 +67,7 @@ class Oracle extends DataModel
     // Date, time and datetime -> string
     oracledb.fetchAsString = [oracledb.CLOB];
     oracledb.extendedMetaData = true;
+    oracledb.poolTimeout = 30;
     //
     if (this.maxRows)
       oracledb.maxRows = this.maxRows;

--- a/public_html/db/postgres.js
+++ b/public_html/db/postgres.js
@@ -63,8 +63,7 @@ class Postgres extends DataModel
     pg.types.setTypeParser(pg.types.builtins.DATE, parseDate);
     pg.types.setTypeParser(pg.types.builtins.TIME, parseDate);
     pg.types.setTypeParser(pg.types.builtins.TIMETZ, parseDate);
-    pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, parseDate);
-  //  pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, parseDate);
+    pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, parseDate);
     //
     return await this.pool.connect();
   }

--- a/public_html/db/sqlserver.js
+++ b/public_html/db/sqlserver.js
@@ -158,8 +158,9 @@ class SQLServer extends DataModel
     else {
       // Serialize extra info
       rs.rowsAffected = result.rowsAffected[0];
-      if (result.recordset)
-        rs.insertId = result.recordset && result.recordsets[0][0].Counter;
+      let row = result.recordsets?.[0]?.[0];
+      if (row && Object.prototype.hasOwnProperty.call(row, "Counter"))
+        rs.insertId = row.Counter;
     }
     //
     return rs;

--- a/public_html/fs/directory.js
+++ b/public_html/fs/directory.js
@@ -180,7 +180,7 @@ class Directory
    */
   async zip()
   {
-    let zipFile = this.fs.file(this.path + ".zip");
+    let zipFile = this.fs.file(`${this.path}.zip`);
     await this.fs.zipDirectory(this, zipFile);
     return zipFile;
   }

--- a/public_html/fs/file.js
+++ b/public_html/fs/file.js
@@ -113,7 +113,7 @@ class File
     //
     // Write utf-8 BOM
     if (this.encoding === "utf-8")
-      await this.write("﻿");
+      await this.write("\ufeff");
   }
 
 

--- a/public_html/fs/nodedriver.js
+++ b/public_html/fs/nodedriver.js
@@ -798,13 +798,9 @@ class NodeDriver extends FS
       //
       response = await require("axios")(opts);
       if (download) {
+        let {pipeline} = require("stream/promises");
         let writeStream = require("fs").createWriteStream(options._file.absolutePath);
-        response.data.pipe(writeStream);
-        //
-        await new Promise((resolve, reject) => {
-          writeStream.on("finish", resolve);
-          writeStream.on("error", reject);
-        });
+        await pipeline(response.data, writeStream);
       }
       //
       return {

--- a/public_html/utils.js
+++ b/public_html/utils.js
@@ -53,14 +53,16 @@ class Utils
     for (let i = 0; i < 256; i++)
       lut[i] = (i < 16 ? "0" : "") + (i).toString(16);
     //
-    let d0 = Math.random() * 0xffffffff | 0;
-    let d1 = Math.random() * 0xffffffff | 0;
-    let d2 = Math.random() * 0xffffffff | 0;
-    let d3 = Math.random() * 0xffffffff | 0;
-    return lut[d0 & 0xff] + lut[d0 >> 8 & 0xff] + lut[d0 >> 16 & 0xff] + lut[d0 >> 24 & 0xff] + "-" +
+    // Use crypto for secure random generation
+    let buf = require("crypto").randomBytes(16);
+    let d0 = buf.readUInt32BE(0);
+    let d1 = buf.readUInt32BE(4);
+    let d2 = buf.readUInt32BE(8);
+    let d3 = buf.readUInt32BE(12);
+    return (lut[d0 & 0xff] + lut[d0 >> 8 & 0xff] + lut[d0 >> 16 & 0xff] + lut[d0 >> 24 & 0xff] + "-" +
             lut[d1 & 0xff] + lut[d1 >> 8 & 0xff] + "-" + lut[d1 >> 16 & 0x0f | 0x40] + lut[d1 >> 24 & 0xff] + "-" +
             lut[d2 & 0x3f | 0x80] + lut[d2 >> 8 & 0xff] + "-" + lut[d2 >> 16 & 0xff] + lut[d2 >> 24 & 0xff] +
-            lut[d3 & 0xff] + lut[d3 >> 8 & 0xff] + lut[d3 >> 16 & 0xff] + lut[d3 >> 24 & 0xff];
+            lut[d3 & 0xff] + lut[d3 >> 8 & 0xff] + lut[d3 >> 16 & 0xff] + lut[d3 >> 24 & 0xff]).toUpperCase();
   }
 
 


### PR DESCRIPTION
Allinea i driver server-side `fs/` e `db/` del cloud-connector alle controparti di IndeRT (sorgente di verità), correggendo i drift di logica dove IndeRT era avanti. Forma adattata allo stile del connector (ES6 class / require locali); le riduzioni CC-specific e gli storage-type non sono toccati.

## Modifiche
- **fs/nodedriver.js** — `httpRequest` (download): migrazione a `stream/promises.pipeline` (propagazione errori + chiusura stream, niente leak dello stream sorgente).
- **fs/directory.js** — `zip`: template literal.
- **fs/file.js** — `create`: BOM scritto come `"﻿"` esplicito invece del carattere U+FEFF letterale (invisibile/fragile).
- **utils.js** — `generateUID36`: random crittografica `crypto.randomBytes` (era `Math.random()`) + output maiuscolo, come IndeRT.
- **db/postgres.js** — `_openConnection`: attivato il type parser `TIMESTAMPTZ` (era commentato) e rimossa la riga `TIMESTAMP` duplicata.
- **db/mysql.js** — `_closeConnection`: `release()` in try/catch con `destroy()` di fallback (rimuove dal pool le connessioni corrotte).
- **db/oracle.js** — `loadModule`: aggiunto `oracledb.poolTimeout = 30`.
- **db/sqlserver.js** — `_execute`: lettura `insertId` resa difensiva (`recordsets?.[0]?.[0]` + `hasOwnProperty("Counter")`).

## Note
- `db/sqlserver.js` `_execute`: la detection INSERT via `includes("insert into ")` è stata lasciata invariata (allineamento fedele richiederebbe `detectDMLCommand`, assente nel connector).
- Differenze CC-ahead (hint TLS, pool error-listener, `tedious` in `getDriverInfo`, `oracle.maxRows`, `normalizePath` segmenti vuoti) non incluse: sono porting in direzione inversa, fuori scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)