### PR TITLE
MS - NodeDriver: chiudi il read stream form-data su errore axios (fd leak upload)

### DIFF
--- a/public_html/fs/nodedriver.js
+++ b/public_html/fs/nodedriver.js
@@ -733,6 +733,8 @@ class NodeDriver extends FS
       validateStatus: () => true // for back compatibility
     };
     //
+    // Keep a reference to the upload stream so its file handle can be closed even if the request fails
+    let uploadStream;
     try {
       let response;
       //
@@ -768,7 +770,8 @@ class NodeDriver extends FS
         delete opts.params;
         //
         if (upload) {
-          formData.append(options._nameField, require("fs").createReadStream(options._file.absolutePath), {
+          uploadStream = require("fs").createReadStream(options._file.absolutePath);
+          formData.append(options._nameField, uploadStream, {
             filename: options._fileName,
             contentType: options._fileContentType
           });
@@ -813,6 +816,10 @@ class NodeDriver extends FS
       return {
         error: e
       };
+    }
+    finally {
+      // Close the upload file handle even when the request failed (on success axios already drained it)
+      uploadStream?.destroy();
     }
   }
 


### PR DESCRIPTION
Mirror del fix `progamma/IndeRT#14478` sul driver `fs/nodedriver.js` del connector.

## Problema
In `NodeDriver.request` (ramo multipart/upload), il `createReadStream` del file passato a form-data non veniva distrutto se `axios(...)` falliva (timeout/4xx/errore di rete) → fd lasciato aperto.

## Fix
Mantenuto un riferimento allo stream di upload e aggiunto `finally { uploadStream?.destroy(); }` attorno alla chiamata axios. Su successo axios ha già drenato lo stream (destroy no-op); su errore l'handle viene chiuso. Allineato alla controparte IndeRT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)